### PR TITLE
Update(docs): add snippet for cloning `next@15` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,30 @@ TypeScript, and Tailwind boilerplate.
 git clone -b next@15 https://github.com/Krish-Das/nextkit.git
 ```
 
-### or clone in current directory:
+### or Clone in current directory:
 
 ```sh
 git clone -b next@15 https://github.com/Krish-Das/nextkit.git .
 ```
 
-### or clone single branch in current directory:
+### or Clone single branch in current directory:
 
 ```sh
 git clone -b next@15 --single-branch https://github.com/Krish-Das/nextkit.git .
 ```
+
+### or Clone in a pre-existing repository (detached HEAD):  
+
+1. Fetch the remote branch:  
+   ```sh
+   git fetch https://github.com/Krish-Das/nextkit.git next@15
+   ```  
+2. Create and checkout a new branch:  
+   ```sh
+   git checkout -b next@15 FETCH_HEAD
+   ```  
+
+---
 
 ## Running locally
 


### PR DESCRIPTION
## Update the README
Adds a quick-start guide to fetch and checkout the `next@15` branch in an existing repo.

**Changes:**
- Adds numbered steps for `git fetch` + `checkout` workflow.