### PR TITLE
chore: add type utility and opaque color preset

### DIFF
--- a/src/css/colors/colors.css
+++ b/src/css/colors/colors.css
@@ -53,6 +53,7 @@
   --fill-secondary: color-mix( in oklab, var(--fill-color) var(--fill-secondary-opacity), transparent);
   --fill-tertiary: color-mix( in oklab, var(--fill-color) var(--fill-tertiary-opacity), transparent);
   --fill-quaternary: color-mix( in oklab, var(--fill-color) var(--fill-quaternary-opacity), transparent);
+  --fill-opaque: color-mix(in oklab, var(--fill-color) 0%, transparent);
 
   --separator-opaque: color-mix( in oklab, var(--separator-opaque-color) 100%, transparent);
   --separator-non-opaque: color-mix( in oklab, var(--separator-non-opaque-color) var(--separator-non-opaque-opacity), transparent);

--- a/src/css/colors/index.css
+++ b/src/css/colors/index.css
@@ -37,6 +37,7 @@
   --color-fill-secondary: var(--fill-secondary);
   --color-fill-tertiary: var(--fill-tertiary);
   --color-fill-quaternary: var(--fill-quaternary);
+  --color-fill-opaque: var(--fill-opaque);
   --color-separator-opaque: var(--separator-opaque);
   --color-separator-non-opaque: var(--separator-non-opaque);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,3 +10,7 @@ export function wait(milliseconds: number) {
     setTimeout(resolve, milliseconds)
   })
 }
+
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}


### PR DESCRIPTION
- Add `Prettify` type helper for flattened type definitions
- Introduce `fill-opaque` Tailwind color for fully opaque backgrounds